### PR TITLE
Use previous version of showdown due to breaking changes in 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "static"
   ],
   "dependencies": {
-    "showdown": "*",
+    "showdown": "^0.5.4",
     "handlebars": "*",
     "grunt": "~0.4.1",
     "lodash": "*",


### PR DESCRIPTION
See release notes: https://github.com/showdownjs/showdown/releases/tag/1.0.0